### PR TITLE
Updated readme for correct composer version syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ With this Laravel package you can validate email input that it contains or not c
 Require this package in your `composer.json` and update composer.
 
 ```php
-"madeitbelgium/laravel-email-domain-validation": "~1.*"
+"madeitbelgium/laravel-email-domain-validation": "~1.0"
 ```
 
 After updating composer, add the ServiceProvider to the providers array in `config/app.php`


### PR DESCRIPTION
<p>Adding <code>1.*</code> to your composer.json file would throw the following error:</p>
<pre><code>[UnexpectedValueException]                                              
  Could not parse version constraint ~1.*: Invalid version string "~1.*"</code></pre>
<p>This PR fixes above.</p>