### PR TITLE
Fix bug in endsWith method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 # PHP Laravel E-mail domain validator
+
 [![Build Status](https://travis-ci.org/madeITBelgium/Laravel-Email-Domain-Validation.svg?branch=master)](https://travis-ci.org/madeITBelgium/Laravel-Email-Domain-Validation)
 [![Coverage Status](https://coveralls.io/repos/github/madeITBelgium/Laravel-Email-Domain-Validation/badge.svg?branch=master)](https://coveralls.io/github/madeITBelgium/Laravel-Email-Domain-Validation?branch=master)
 [![Latest Stable Version](https://poser.pugx.org/madeITBelgium/Laravel-Email-Domain-Validation/v/stable.svg)](https://packagist.org/packages/madeITBelgium/Laravel-Email-Domain-Validation)
@@ -29,7 +30,9 @@ You can use the facade for shorter code. Add this to your aliases:
 ```
 
 # Documentation
+
 ## Usage
+
 ```php
 $emailDomain = new EmailDomain('info@madeit.be', ['madeit.be'], ['tpweb.org']);
 $emailDomain->isEmailValid() //Checks if the given e-mail address is valid
@@ -41,7 +44,8 @@ $emailDomain->isEmailAllowed() //Check if the email address is allowed.
 $emailDomain->isEmailAllowed('info@madeit.be', ['madeit.be'], ['example.com']));
 ```
 
-## Laraval validator
+## Laravel validator
+
 ```php
 public function store(Request $request) {
     $this->validate($request, ['email' => 'required|email|domain:madeit.be,hotmail.com|domainnot:gmail.com,yahoo.com']);
@@ -57,6 +61,7 @@ Support github or mail: tjebbe.lievens@madeit.be
 # Contributing
 
 Please try to follow the psr-2 coding style guide. http://www.php-fig.org/psr/psr-2/
+
 # License
 
 This package is licensed under LGPL. You are free to use it in personal and commercial projects. The code can be forked and modified, but the original copyright author should always be included!

--- a/src/EmailDomain.php
+++ b/src/EmailDomain.php
@@ -215,14 +215,14 @@ class EmailDomain
     private function isDomainnameValid($domainname)
     {
         return preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $domainname) //valid chars check
-            && preg_match('/^.{1,253}$/', $domainname) //overall length check
-            && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domainname); //length of each label
+         && preg_match('/^.{1,253}$/', $domainname) //overall length check
+         && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domainname); //length of each label
     }
 
     private function endsWith($haystack, $needle)
     {
-        $expectedPosition = strlen($haystack) - strlen($needle);
+        $needle = '@' . $needle;
 
-        return strripos($haystack, $needle, 0) === $expectedPosition;
+        return ends_with($haystack, $needle);
     }
 }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -15,6 +15,7 @@ class validateTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new Validator();
         $this->assertTrue($validator->isEmailAllowed('info@madeit.be', ['madeit.be']));
+        $this->assertFalse($validator->isEmailAllowed('info@notmadeit.be', ['madeit.be']));
     }
 
     public function testValidatorNotInDomain()


### PR DESCRIPTION
EndsWith method makes the validation to allow domains that end with an allowed domain but do not match exactly the expected domain.

For example, if we tell the library to accept mydomain.com and then we pass the email notmydomain.com the validator will return true.

This pull request should fix this issue.

Includes an unit test for the example proposed before.